### PR TITLE
Add Guzzle version 7 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": ">=5.6.4",
-        "guzzlehttp/guzzle": "~6.0"
+        "guzzlehttp/guzzle": "^6.0|^7.0"
     },
     "require-dev": {
         "mockery/mockery": "0.9.*",


### PR DESCRIPTION
This should resolve errors like:
```
Using version ^1.0 for hcgcloud/pterodactyl-sdk
./composer.json has been updated
Running composer update hcgcloud/pterodactyl-sdk
Loading composer repositories with package information
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - hcgcloud/pterodactyl-sdk[v1.0.0, ..., v1.0.4] require guzzlehttp/guzzle ~6.0 -> found guzzlehttp/guzzle[6.0.0, ..., 6.5.x-dev] but it conflicts with your root composer.json require (^7.0.1).
    - Root composer.json requires hcgcloud/pterodactyl-sdk ^1.0 -> satisfiable by hcgcloud/pterodactyl-sdk[v1.0.0, ..., v1.0.4].

Use the option --with-all-dependencies (-W) to allow upgrades, downgrades and removals for packages currently locked to specific versions.

Installation failed, reverting ./composer.json and ./composer.lock to their original content.
```
Example error from trying to install the SDK in a fresh Laravel 8 application.

Plus Guzzle 6 to 7 does not change any features used in the SDK at this point.

Thanks.