### PR TITLE
Fixed get request with query parameters

### DIFF
--- a/src/Http.php
+++ b/src/Http.php
@@ -85,7 +85,7 @@ class Http
      */
     public function get($uri, array $query = [])
     {
-        return $this->request('GET', $uri, [], $query);
+        return $this->request('GET', $uri, $query);
     }
 
     /**


### PR DESCRIPTION
Currently query parameters in a GET request are being sent to the api as a body payload.
This isn't the correct behavior of a GET request and causes the  query parameters are not correctly sent and interpreted by the API.

Closes #32 